### PR TITLE
Added ACL switch to S3 sync command

### DIFF
--- a/dynamodb-dump
+++ b/dynamodb-dump
@@ -98,7 +98,7 @@ done
 
 echo "Uploading backup"
 
-aws s3 sync . s3://$S3_FOLDER/$(date +%Y-%m-%d-%H-%M-%S)
+aws s3 sync --acl=bucket-owner-full-control . s3://$S3_FOLDER/$(date +%Y-%m-%d-%H-%M-%S)
 error=$?
 if [ "$error" -ne 0 ]; then
     sns-alert S3 $error


### PR DESCRIPTION
By adding the acl bucket-owner-full-control switch, the receiving bucket owner has control of the objects placed in their bucket.
When this script is used within the same account this isn't an issue.  In our case, I'm directing the DynamoDB output to a bucket in a different AWS account.  Without this value, a user in the receiving account can't manage the export.  Hope this helps.